### PR TITLE
Add pac-ret hardening to _init and _fini

### DIFF
--- a/crt/aarch64/crti.s
+++ b/crt/aarch64/crti.s
@@ -2,6 +2,7 @@
 .global _init
 .type _init,%function
 _init:
+	paciasp
 	stp x29,x30,[sp,-16]!
 	mov x29,sp
 
@@ -9,5 +10,6 @@ _init:
 .global _fini
 .type _fini,%function
 _fini:
+	paciasp
 	stp x29,x30,[sp,-16]!
 	mov x29,sp

--- a/crt/aarch64/crtn.s
+++ b/crt/aarch64/crtn.s
@@ -1,7 +1,9 @@
 .section .init
 	ldp x29,x30,[sp],#16
+	autiasp
 	ret
 
 .section .fini
 	ldp x29,x30,[sp],#16
+	autiasp
 	ret


### PR DESCRIPTION
Ideally, this should be conditional on whether ptrauth_returns is requested and which key is used, but this patch still should be safe as PACIASP and AUTIASP are encoded as HINT and both prologue and epilogue use the same IA key.

Please note that even if `.init_array` and `.fini_array` are actually used, `_init` and `_fini` functions are statically linked into every executable, thus this patch is a natural way to silence multiple warnings reported by PAuth gadget scanner for every executable.