### PR TITLE
aarch64: initial pauth support

### DIFF
--- a/arch/aarch64/reloc.h
+++ b/arch/aarch64/reloc.h
@@ -18,7 +18,39 @@
 #define REL_DTPMOD      R_AARCH64_TLS_DTPMOD64
 #define REL_DTPOFF      R_AARCH64_TLS_DTPREL64
 #define REL_TPOFF       R_AARCH64_TLS_TPREL64
+
+#ifndef __has_feature
+#define __has_feature(x) 0
+#endif
+
+#if __has_feature(ptrauth_elf_got)
+#define R_AARCH64_AUTH_TLSDESC 0x413
+#define REL_TLSDESC     R_AARCH64_AUTH_TLSDESC
+#else
 #define REL_TLSDESC     R_AARCH64_TLSDESC
+#endif
 
 #define CRTJMP(pc,sp) __asm__ __volatile__( \
 	"mov sp,%1 ; br %0" : : "r"(pc), "r"(sp) : "memory" )
+
+#if __has_feature(ptrauth_intrinsics)
+
+#include <stdint.h>
+
+#define TARGET_RELOCATE(dso, type, reladdr, sym, addend, is_phase_2, dyn, error_sym) \
+	do_target_reloc(dso, type, reladdr, sym, addend, is_phase_2, dyn, error_sym)
+#define DO_TARGET_RELR(dso, dyn) do_pauth_relr(dso, dyn)
+
+int do_target_reloc(int type, uint64_t* reladdr, uint64_t base, uint64_t symval,
+                    uint64_t addend, int is_phase_2, uint64_t* dyn, uint64_t error_sym);
+
+void do_pauth_relr(uint64_t base, uint64_t* dyn);
+
+#define GETFUNCSYM(fp, sym, got) do { \
+	hidden void sym(); \
+	*(fp) = sym; } while(0)
+
+#define FPTR_CAST(fty, p) \
+	((fty)__builtin_ptrauth_sign_unauthenticated((void*)(p), 0, 0))
+
+#endif

--- a/crt/aarch64/crti.s
+++ b/crt/aarch64/crti.s
@@ -2,6 +2,7 @@
 .global _init
 .type _init,%function
 _init:
+	paciasp
 	stp x29,x30,[sp,-16]!
 	mov x29,sp
 
@@ -9,5 +10,6 @@ _init:
 .global _fini
 .type _fini,%function
 _fini:
+	paciasp
 	stp x29,x30,[sp,-16]!
 	mov x29,sp

--- a/crt/aarch64/crtn.s
+++ b/crt/aarch64/crtn.s
@@ -1,7 +1,9 @@
 .section .init
 	ldp x29,x30,[sp],#16
+	autiasp
 	ret
 
 .section .fini
 	ldp x29,x30,[sp],#16
+	autiasp
 	ret

--- a/src/internal/dynlink.h
+++ b/src/internal/dynlink.h
@@ -111,7 +111,7 @@ hidden void __dl_seterr(const char *, ...);
 hidden int __dl_invalid_handle(void *);
 hidden void __dl_vseterr(const char *, va_list);
 
-hidden ptrdiff_t __tlsdesc_static(), __tlsdesc_dynamic();
+hidden ptrdiff_t __tlsdesc_static(), __tlsdesc_dynamic(), __tlsdesc_undef_weak();
 
 hidden extern int __malloc_replaced;
 hidden extern int __aligned_alloc_replaced;

--- a/src/ldso/aarch64/reloc.c
+++ b/src/ldso/aarch64/reloc.c
@@ -1,0 +1,165 @@
+#include "reloc.h"
+
+#if __has_feature(ptrauth_intrinsics)
+
+#include <stdint.h>
+
+#define R_AARCH64_AUTH_ABS64    0x244
+/* Define R_AARCH64_JUMP_SLOT manually to avoid including elf.h. */
+#define R_AARCH64_JUMP_SLOT     0x402
+#define R_AARCH64_AUTH_RELATIVE 0x411
+#define R_AARCH64_AUTH_GLOB_DAT 0x412
+
+#define DT_AARCH64_PAC_PLT      0x70000003
+#define DT_AARCH64_AUTH_RELRSZ  0x70000011
+#define DT_AARCH64_AUTH_RELR    0x70000012
+#define DT_AARCH64_AUTH_RELRENT 0x70000013
+
+static uint64_t do_sign_ia(uint64_t modifier, uint64_t value)
+{
+	__asm__ ("pacia %0, %1" : "+r" (value) : "r" (modifier));
+	return value;
+}
+
+static uint64_t do_sign_ib(uint64_t modifier, uint64_t value)
+{
+	__asm__ ("pacib %0, %1" : "+r" (value) : "r" (modifier));
+	return value;
+}
+
+static uint64_t do_sign_da(uint64_t modifier, uint64_t value)
+{
+	__asm__ ("pacda %0, %1" : "+r" (value) : "r" (modifier));
+	return value;
+}
+
+static uint64_t do_sign_db(uint64_t modifier, uint64_t value)
+{
+	__asm__ ("pacdb %0, %1" : "+r" (value) : "r" (modifier));
+	return value;
+}
+
+static int do_pauth_reloc(uint64_t* reladdr, uint64_t value)
+{
+	if (value == 0) {
+		*reladdr = 0;
+		return 1;
+	}
+	uint64_t schema = *reladdr;
+	unsigned discrim = (schema >> 32) & 0xffff;
+	int addr_div = schema >> 63;
+	int key = (schema >> 60) & 0x3;
+	uint64_t modifier = discrim;
+	if (addr_div)
+		modifier = (modifier << 48) | (uint64_t)reladdr;
+
+	switch (key) {
+		default:
+			*reladdr = do_sign_ia(modifier, value);
+			break;
+		case 1:
+			*reladdr = do_sign_ib(modifier, value);
+			break;
+		case 2:
+			*reladdr = do_sign_da(modifier, value);
+			break;
+		case 3:
+			*reladdr = do_sign_db(modifier, value);
+			break;
+	}
+	return 1;
+}
+
+static int has_dyn_tag(uint64_t* dyn, uint64_t tag)
+{
+	while (*dyn) {
+		if (*dyn == tag)
+			return 1;
+		dyn += 2;
+	}
+	return 0;
+}
+
+int do_target_reloc(int type, uint64_t* reladdr, uint64_t base,
+                    uint64_t symval, uint64_t addend, int is_phase_2,
+                    uint64_t* dyn, uint64_t error_sym)
+{
+	if (type == R_AARCH64_JUMP_SLOT && has_dyn_tag(dyn, DT_AARCH64_PAC_PLT)) {
+		*reladdr = do_sign_ia((uint64_t)reladdr, *reladdr);
+		return 1;
+	}
+	if (type == R_AARCH64_AUTH_GLOB_DAT) {
+		/* We can't rely on is_phase_2 here, so check if the relocation slot is not filled.
+		 * Check bits 0...47 against null:
+		 * - before relocation is resolved, these are known to contain zeros:
+		 *   - bits 0...31 store addend which is known to be zero for GOT slots;
+		 *   - bits 32...47 store discriminator which is known to be zero for GOT slots;
+		 * - after relocation is resolved to a non-undef symbol, these would contain
+		 *   non-null value since typically virtual address width is 48 bits or lower.
+		 * We cannot check the whole slot contents against null since before the relocation is
+		 * resolved, bits 60...63 contain signing scheme (key value and address diversity flag).
+		 *
+		 * See:
+		 * - https://github.com/ARM-software/abi-aa/blob/2025Q1/pauthabielf64/pauthabielf64.rst#encoding-the-signing-schema
+		 * - https://github.com/ARM-software/abi-aa/blob/2025Q1/pauthabielf64/pauthabielf64.rst#default-signing-schema */
+		if ((*reladdr & 0xffffffffffffull) == 0)
+			return do_pauth_reloc(reladdr, symval + addend);
+		return 1;
+	}
+	/* We don't process auth relocs until we load all dependencies */
+	if (is_phase_2)
+		return 1;
+	/* NOTE: we have to rely on this hack since we set error = error_impl in __dls3 manually. */
+	if (*reladdr == error_sym)
+		return 1;
+	switch (type)
+	{
+		case R_AARCH64_AUTH_ABS64:
+			return do_pauth_reloc(reladdr, symval + addend);
+		case R_AARCH64_AUTH_RELATIVE:
+			return do_pauth_reloc(reladdr, base + addend);
+		default:
+			return 0;
+	}
+}
+
+static uint64_t dyn_value(uint64_t* dyn, uint64_t tag)
+{
+	while (*dyn)
+	{
+		if (*dyn == tag)
+			return dyn[1];
+		else
+			dyn += 2;
+	}
+	return 0;
+}
+
+void do_pauth_relr(uint64_t base, uint64_t* dyn)
+{
+	uint64_t* relr = (uint64_t*)dyn_value(dyn, DT_AARCH64_AUTH_RELR);
+	if (relr == 0)
+		return;
+	uint64_t relr_size = dyn_value(dyn, DT_AARCH64_AUTH_RELRSZ);
+	uint64_t relr_ent = dyn_value(dyn, DT_AARCH64_AUTH_RELRENT);
+	if (relr_ent != sizeof(uint64_t))
+		return;
+	uint64_t *reloc_addr;
+	for (; relr_size; relr++, relr_size-=relr_ent) {
+		if ((relr[0]&1) == 0) {
+			reloc_addr = (uint64_t*)(base + relr[0]);
+			do_pauth_reloc(reloc_addr, base + (*reloc_addr & 0xffffffff));
+			reloc_addr++;
+		} else {
+			int i = 0;
+			for (uint64_t bitmap=relr[0]; (bitmap>>=1); ++i)
+				if (bitmap&1) {
+					uint64_t val = base + (reloc_addr[i] & 0xffffffff);
+					do_pauth_reloc(&reloc_addr[i], val);
+				}
+			reloc_addr += 8*sizeof(uint64_t)-1;
+		}
+	}
+}
+
+#endif

--- a/src/ldso/aarch64/tlsdesc.S
+++ b/src/ldso/aarch64/tlsdesc.S
@@ -1,3 +1,7 @@
+#ifndef __has_feature
+#define __has_feature(x) 0
+#endif
+
 // size_t __tlsdesc_static(size_t *a)
 // {
 // 	return a[1];
@@ -6,7 +10,20 @@
 .hidden __tlsdesc_static
 .type __tlsdesc_static,@function
 __tlsdesc_static:
+#if __has_feature(ptrauth_elf_got)
+	add   x17,x0,8
+	ldr   x16,[x17]
+	autda x16,x17
+	mov   x17,x16
+	xpacd x17
+	cmp   x16,x17
+	b.eq  .Lauth_success_0
+	brk   #0xc472
+.Lauth_success_0:
+	mov   x0,x16
+#else
 	ldr x0,[x0,#8]
+#endif
 	ret
 
 // size_t __tlsdesc_dynamic(size_t *a)
@@ -21,11 +38,33 @@ __tlsdesc_static:
 __tlsdesc_dynamic:
 	stp x1,x2,[sp,#-16]!
 	mrs x1,tpidr_el0      // tp
+#if __has_feature(ptrauth_elf_got)
+	add   x17,x0,8
+	ldr   x16,[x17]
+	autda x16,x17
+	mov   x17,x16
+	xpacd x17
+	cmp   x16,x17
+	b.eq  .Lauth_success_1
+	brk   #0xc472
+.Lauth_success_1:
+	mov   x0,x16
+#else
 	ldr x0,[x0,#8]        // p
+#endif
 	ldp x0,x2,[x0]        // p->modidx, p->off
 	sub x2,x2,x1          // p->off - tp
 	ldr x1,[x1,#-8]       // dtv
 	ldr x1,[x1,x0,lsl #3] // dtv[p->modidx]
 	add x0,x1,x2          // dtv[p->modidx] + p->off - tp
 	ldp x1,x2,[sp],#16
+	ret
+
+.global __tlsdesc_undef_weak
+.hidden __tlsdesc_undef_weak
+.type __tlsdesc_undef_weak,@function
+__tlsdesc_undef_weak:
+	mov x0, #0
+	mrs x8, TPIDR_EL0
+	sub x0, x0, x8
 	ret

--- a/src/signal/sigaction.c
+++ b/src/signal/sigaction.c
@@ -48,6 +48,11 @@ int __libc_sigaction(int sig, const struct sigaction *restrict sa, struct sigact
 #ifdef SA_RESTORER
 		ksa.flags |= SA_RESTORER;
 		ksa.restorer = (sa->sa_flags & SA_SIGINFO) ? __restore_rt : __restore;
+#if __has_feature(ptrauth_calls)
+		/* When the restorer is called by kernel, the restorer pointer is expected to be unsigned.
+		 * It was previously implicitly signed, so strip the signature manually. */
+		ksa.restorer = __builtin_ptrauth_strip(ksa.restorer, 0);
+#endif
 #endif
 		memcpy(&ksa.mask, &sa->sa_mask, _NSIG/8);
 	}

--- a/src/thread/aarch64/clone.S
+++ b/src/thread/aarch64/clone.S
@@ -4,6 +4,10 @@
 // syscall(SYS_clone, flags, stack, ptid, tls, ctid)
 //         x8,        x0,    x1,    x2,   x3,  x4
 
+#ifndef __has_feature
+#define __has_feature(x) 0
+#endif
+
 .global __clone
 .hidden __clone
 .type   __clone,%function
@@ -25,6 +29,10 @@ __clone:
 	ret
 	// child
 1:	ldp x1,x0,[sp],#16
+#if __has_feature(ptrauth_calls) // TODO
+	blraaz x1
+#else
 	blr x1
+#endif
 	mov x8,#93 // SYS_exit
 	svc #0


### PR DESCRIPTION
1. Support PAuth dynamic relocs:

   - R_AARCH64_AUTH_ABS64;
   - R_AARCH64_AUTH_RELATIVE (including relr);
   - R_AARCH64_JUMP_SLOT (sign slot contents if DT_AARCH64_PAC_PLT dynamic tag is present);
   - R_AARCH64_AUTH_GLOB_DAT;
   - R_AARCH64_AUTH_TLSDESC.

2. Support signed function pointers in init/fini arrays (with optional address discrimination enabled).

3. Check PAuth core info compatibility for DSOs in the process.

TODO:

1. Support function pointer type discrimination. This should not be enabled under normal conditions though, and pauthtest ABI in LLVM intentionally does not include that.

2. Do not store unsigned LR in memory in raw assembly code: see https://github.com/access-softek/musl/issues/3.

3. Support non-null `__ehdr_start`. See in-code comment in `__dls2` function in src/dynlink.c for details.

4. Enhance test coverage: current proof-of-concept is good enough to run llvm-test-suite, but we lack test coverage of some parts of musl.