### PR TITLE
Strip sa_handler if ptrauth_calls is present

### DIFF
--- a/src/signal/sigaction.c
+++ b/src/signal/sigaction.c
@@ -44,6 +44,9 @@ int __libc_sigaction(int sig, const struct sigaction *restrict sa, struct sigact
 			}
 		}
 		ksa.handler = sa->sa_handler;
+#if __has_feature(ptrauth_calls)
+		ksa.handler = __builtin_ptrauth_strip(ksa.handler, 0);
+#endif
 		ksa.flags = sa->sa_flags;
 #ifdef SA_RESTORER
 		ksa.flags |= SA_RESTORER;


### PR DESCRIPTION
Strip sa_handler if ptrauth_calls is present

This follows the same logic as for the restorer. Without stripping
kernel would receive a signed address and use it, as is, to call the
signal handler, which would result in an invalid memory access.

For the record, this was spotted when running Rust signal handler as
registered here (`fn init()`):
https://github.com/rust-lang/rust/blob/main/library/std/src/sys/pal/unix/stack_overflow.rs#L184

Sample strace output showing invalid (signed) pointer:

```
    rt_sigaction(SIGSEGV, {sa_handler=0x13f96bba92acf8, sa_mask=[],
      sa_flags=SA_RESTORER|SA_ONSTACK|SA_SIGINFO, sa_restorer=0xf96bbaad0430},
      NULL, 8) = 0
```